### PR TITLE
Update avr-asm.tmLanguage

### DIFF
--- a/avr-asm.tmLanguage
+++ b/avr-asm.tmLanguage
@@ -12,6 +12,23 @@
 	<key>patterns</key>
 	<array>
 		<dict>
+			<key>match</key>
+			<string>(rjmp|rcall|brbs|brbc|breq|brne|brcs|brcc|brsh|brlo|brmi|brpl|brge|brlt|brhs|brhc|brts|brtc|brvs|brvc|brie|brid)\s+(\w+)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.asm</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.function</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
 			<key>comment</key>
 			<string>General purpose register set</string>
 			<key>match</key>
@@ -20,10 +37,8 @@
 			<string>storage.type.asm</string>
 		</dict>
 		<dict>
-			<key>comment</key>
-			<string>General purpose register set (16-bit pointers)</string>
 			<key>match</key>
-			<string>(?i)\b(xl|xh|yl|yh|zl|zh)\b</string>
+			<string>(?i)\b(X|Y|Z|XL|XH|YL|YH|ZL|ZH|PC|ZERO)\b</string>
 			<key>name</key>
 			<string>storage.type.asm</string>
 		</dict>
@@ -31,7 +46,7 @@
 			<key>comment</key>
 			<string>Arithmetic and logic instruction mnemonics</string>
 			<key>match</key>
-			<string>(?i)\b(add|adc|sub|subi|sbc|sbci|sbiw|and|andi|or|ori|eor|com|neg|sbr|cbr|inc|dec|tst|clr|ser)\b</string>
+			<string>(?i)\b(add|adc|adiw|sub|subi|sbc|sbci|sbiw|and|andi|or|ori|eor|com|neg|sbr|cbr|inc|dec|tst|clr|ser)\b</string>
 			<key>name</key>
 			<string>keyword.operator.asm</string>
 		</dict>
@@ -39,7 +54,7 @@
 			<key>comment</key>
 			<string>Branch instruction mnemonics</string>
 			<key>match</key>
-			<string>(?i)\b(rjmp|ijmp|rcall|ret|reti|cpse|cp|cpc|cpi|sbrc|sbrs|sbic|sbis|brbs|brbc|breq|brne|brcs|brcc|brsh|brlo|brmi|brpl|brge|brlt|brhs|brhc|brts|brtc|brvs|brvc|brie|brid)\b</string>
+			<string>(?i)\b(rjmp|ijmp|rcall|icall|ret|reti|cpse|cp|cpc|cpi|sbrc|sbrs|sbic|sbis|brbs|brbc|breq|brne|brcs|brcc|brsh|brlo|brmi|brpl|brge|brlt|brhs|brhc|brts|brtc|brvs|brvc|brie|brid)\b</string>
 			<key>name</key>
 			<string>keyword.operator.asm</string>
 		</dict>
@@ -72,6 +87,22 @@
 			<string>AVR ASM 1.0 directives</string>
 			<key>match</key>
 			<string>(?i)(^|\s)\.(byte|cseg|csegsize|db|dd|def|device|dq|dseg|dw|elif|else|endif|endm|endmacro|equ|error|eseg|exit|if|ifdef|ifndef|include|list|listmac|macro|message|nolist|org|set|undef)</string>
+			<key>name</key>
+			<string>constant.character.asm</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>AVR ASM 1.0 directives</string>
+			<key>match</key>
+			<string>(?i)\#(define|undef|ifdef|ifndef|if|elif|else|endif|error|warning|message|include|pragma)</string>
+			<key>name</key>
+			<string>constant.character.asm</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>AVR ASM 1.0 directives</string>
+			<key>match</key>
+			<string>(?i)(low|high|byte2|byte3|byte4|lwrd|hwrd|page|exp2|log2)</string>
 			<key>name</key>
 			<string>constant.character.asm</string>
 		</dict>
@@ -137,7 +168,7 @@
 			<key>comment</key>
 			<string>Dec number constant</string>
 			<key>match</key>
-			<string>\b(0|[1-9]\d+)\b</string>
+			<string>\-?\b(\d+)\b</string>
 			<key>name</key>
 			<string>constant.numeric.asm</string>
 		</dict>


### PR DESCRIPTION
Added missing registers (X, Y, Z, PC, ZERO), missing instructions (adiw, icall), #-directives
Labels after jump command (e.g. rjmp, brcs, etc.) are now colored.
